### PR TITLE
feat: add config file support

### DIFF
--- a/.dict-be.yml.example
+++ b/.dict-be.yml.example
@@ -1,0 +1,5 @@
+llm:
+  url: "https://api.openai.com/v1"
+  model: "gpt-4o-mini"
+  token: "your-api-token"
+  type: "openai"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,41 @@
+package config
+
+import (
+	"fmt"
+
+	"github.com/spf13/viper"
+)
+
+type Config struct {
+	LLM LLMConfig `mapstructure:"llm"`
+}
+
+type LLMConfig struct {
+	URL   string `mapstructure:"url"`
+	Model string `mapstructure:"model"`
+	Token string `mapstructure:"token"`
+	Type  string `mapstructure:"type"`
+}
+
+func Load() (Config, error) {
+	var cfg Config
+	if err := viper.Unmarshal(&cfg); err != nil {
+		return cfg, err
+	}
+	if err := cfg.Validate(); err != nil {
+		return cfg, err
+	}
+	return cfg, nil
+}
+
+func (c Config) Validate() error {
+	if c.LLM.Type == "" {
+		return nil
+	}
+	switch c.LLM.Type {
+	case "openai", "anthropics", "gemini":
+		return nil
+	default:
+		return fmt.Errorf("invalid llm.type: %s", c.LLM.Type)
+	}
+}


### PR DESCRIPTION
Add --config with a default path in the home directory and introduce LLM configuration parsing with basic type validation, plus an example config file for reference.

Change-Id: I2a5f7fe4389f4dc97d990084e21893000cdbdb1c
Co-developed-by: Cursor <noreply@cursor.com>