### PR TITLE
feat(cli): add query command

### DIFF
--- a/internal/cli/query.go
+++ b/internal/cli/query.go
@@ -1,0 +1,56 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func newQueryCmd() *cobra.Command {
+	var inputFile string
+	cmd := &cobra.Command{
+		Use:   "query [text...]",
+		Short: "Read query from args, file, or stdin",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			input, err := readInput(args, inputFile, cmd.InOrStdin())
+			if err != nil {
+				return err
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), input)
+			return nil
+		},
+	}
+	cmd.Flags().StringVarP(&inputFile, "file", "F", "", "query file, use -F- for stdin")
+	return cmd
+}
+
+func readInput(args []string, inputFile string, stdin io.Reader) (string, error) {
+	if inputFile != "" && len(args) > 0 {
+		return "", fmt.Errorf("input args and -F are mutually exclusive")
+	}
+	if inputFile == "" {
+		if len(args) == 0 {
+			return "", fmt.Errorf("missing input: provide args or -F")
+		}
+		return strings.Join(args, " "), nil
+	}
+	if inputFile == "-" {
+		data, err := io.ReadAll(stdin)
+		if err != nil {
+			return "", fmt.Errorf("read stdin: %w", err)
+		}
+		return trimTrailingNewline(string(data)), nil
+	}
+	data, err := os.ReadFile(inputFile)
+	if err != nil {
+		return "", fmt.Errorf("read file: %w", err)
+	}
+	return trimTrailingNewline(string(data)), nil
+}
+
+func trimTrailingNewline(value string) string {
+	return strings.TrimRight(value, "\r\n")
+}

--- a/internal/cli/query_test.go
+++ b/internal/cli/query_test.go
@@ -1,0 +1,57 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReadQueryFromArgs(t *testing.T) {
+	input, err := readInput([]string{"hello", "world"}, "", strings.NewReader(""))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if input != "hello world" {
+		t.Fatalf("unexpected input: %q", input)
+	}
+}
+
+func TestReadQueryFromFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "input.txt")
+	if err := os.WriteFile(path, []byte("file input\n"), 0o600); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+	input, err := readInput(nil, path, strings.NewReader(""))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if input != "file input" {
+		t.Fatalf("unexpected input: %q", input)
+	}
+}
+
+func TestReadQueryFromStdin(t *testing.T) {
+	input, err := readInput(nil, "-", strings.NewReader("stdin input\n"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if input != "stdin input" {
+		t.Fatalf("unexpected input: %q", input)
+	}
+}
+
+func TestReadQueryMissing(t *testing.T) {
+	_, err := readInput(nil, "", strings.NewReader(""))
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestReadQueryConflict(t *testing.T) {
+	_, err := readInput([]string{"hello"}, "input.txt", strings.NewReader(""))
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -39,6 +39,7 @@ func NewRootCmd() *cobra.Command {
 	)
 	_ = viper.BindPFlag("config", root.PersistentFlags().Lookup("config"))
 
+	root.AddCommand(newQueryCmd())
 	root.AddCommand(newVersionCmd())
 	return root
 }


### PR DESCRIPTION
Add a dedicated input command so users can provide text via args, file input, or stdin with a consistent interface. This improves scriptability while keeping input parsing logic centralized and covered by tests.

Change-Id: Ib958d8eef6e00ae255ce9a182b28a33d9249edb6
Co-developed-by: Cursor <noreply@cursor.com>