### PR TITLE
feat(cli): add query translation prompts

### DIFF
--- a/internal/cli/prompts/query_system.md
+++ b/internal/cli/prompts/query_system.md
@@ -1,0 +1,6 @@
+You are a translation assistant. Based on the user's input, translate the text from {{input_language}} to {{output_language}}.
+Output must be in the target language ({{output_language}}).
+Do not translate or alter the <input> tags; only translate the text inside them.
+Please provide the translation and include:
+- Language difficulties: point out the most error-prone or important grammar/semantic points.
+- Vocabulary memory tips: give memory techniques for key words or phrases.

--- a/internal/cli/prompts/query_user.md
+++ b/internal/cli/prompts/query_user.md
@@ -1,0 +1,4 @@
+Translate the following text from {{input_language}} to {{output_language}}.
+Output must be in the target language ({{output_language}}).
+Do not translate or alter the <input> tags; only translate the text inside them.
+<input>{{input}}</input>

--- a/internal/cli/query_system.md
+++ b/internal/cli/query_system.md
@@ -1,0 +1,6 @@
+You are a translation assistant. Based on the user's input, translate the text from {{input_language}} to {{output_language}}.
+Output must be in the target language ({{output_language}}).
+Do not translate or alter the <input> tags; only translate the text inside them.
+Please provide the translation and include:
+- Language difficulties: point out the most error-prone or important grammar/semantic points.
+- Vocabulary memory tips: give memory techniques for key words or phrases.

--- a/internal/cli/query_test.go
+++ b/internal/cli/query_test.go
@@ -85,3 +85,16 @@ func TestResolveLanguagesNoAuto(t *testing.T) {
 		t.Fatalf("unexpected output language: %q", outputLang)
 	}
 }
+
+func TestBuildQueryPrompts(t *testing.T) {
+	systemPrompt, userPrompt, err := buildQueryPrompts("hello", "English", "Simplified Chinese")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(systemPrompt, "English") || !strings.Contains(systemPrompt, "Simplified Chinese") {
+		t.Fatalf("unexpected system prompt: %q", systemPrompt)
+	}
+	if !strings.Contains(userPrompt, "<input>hello</input>") {
+		t.Fatalf("unexpected user prompt: %q", userPrompt)
+	}
+}

--- a/internal/cli/query_user.md
+++ b/internal/cli/query_user.md
@@ -1,0 +1,4 @@
+Translate the following text from {{input_language}} to {{output_language}}.
+Output must be in the target language ({{output_language}}).
+Do not translate or alter the <input> tags; only translate the text inside them.
+<input>{{input}}</input>


### PR DESCRIPTION
Use template files to build system/user prompts for query translation and clarify tag handling and target language output.

Change-Id: Ic15e6a93171d46721d1b1d746686490aa57fc416
Co-developed-by: Cursor <noreply@cursor.com>